### PR TITLE
chore: update ccusage 17.1.3 → 18.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
         "autoprefixer": "^10.4.21",
-        "ccusage": "17.1.3",
+        "ccusage": "18.0.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -3370,9 +3370,10 @@
       ]
     },
     "node_modules/ccusage": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/ccusage/-/ccusage-17.1.3.tgz",
-      "integrity": "sha512-1fgnlS3kLQo61m7Nz5AUj7le57+K6JaSN5KC0/hD+oNzRvg6Uss0TNKLCuIjNjm7b0LCiN+4DjKSNHJWCiAwxg==",
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/ccusage/-/ccusage-18.0.8.tgz",
+      "integrity": "sha512-9GLGh8FYNBRz5BSqF/cZ0/JtdO9X/vnwmk0kIRaye6UvFjpu/CtRaD4BhKtmErrU6V8dTXh+5bTnCSTi84qvQA==",
+      "license": "MIT",
       "bin": {
         "ccusage": "dist/index.js"
       },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "autoprefixer": "^10.4.21",
-    "ccusage": "17.1.3",
+    "ccusage": "18.0.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
## Summary

- Bumps `ccusage` from `17.1.3` to `18.0.8` (latest stable release)
- Verified full backward compatibility with the existing `data-loader` API: `loadSessionBlockData` and `loadDailyUsageData` function signatures are unchanged
- The only new addition is an optional `usageLimitResetTime?: Date` field on `SessionBlock`, which is non-breaking

## Test plan

- [ ] Run `npm install` to confirm lockfile resolves cleanly
- [ ] Launch the app with `npm run electron-dev` and verify the menu bar displays usage data correctly
- [ ] Confirm Dashboard, Live Monitoring, Analytics, and Settings tabs all load without errors
- [ ] Check that session block data and daily usage data are fetched and displayed as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)