### PR TITLE
fix: resolve broken features, bugs, and dead code

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import { Analytics } from './components/Analytics';
 import { Dashboard } from './components/Dashboard';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { LiveMonitoring } from './components/LiveMonitoring';
 import { LoadingScreen } from './components/LoadingScreen';
 import { NavigationTabs } from './components/NavigationTabs';
 import { SettingsPanel } from './components/SettingsPanel';
@@ -505,6 +506,10 @@ const App: React.FC = () => {
             <div className="space-y-3 pb-3">
               {state.currentView === 'dashboard' && (
                 <Dashboard stats={currentStats} status={usageStatus} />
+              )}
+
+              {state.currentView === 'live' && (
+                <LiveMonitoring stats={currentStats} onRefresh={refreshData} />
               )}
 
               {state.currentView === 'analytics' && (

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { formatNumber } from '../lib/utils';
 import type { UsageStats } from '../types/usage';
 import { Button } from './ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
@@ -14,13 +15,6 @@ type ChartTimeRange = '7d' | '30d';
 type ChartType = 'area' | 'line' | 'bar';
 
 // Helper functions extracted to reduce complexity
-const formatNumber = (num: number) => {
-  if (!num || Number.isNaN(num)) return '0';
-  if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
-  if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;
-  return num.toLocaleString();
-};
-
 const formatCurrency = (amount: number) => {
   if (!amount || Number.isNaN(amount)) return '$0.000';
   return new Intl.NumberFormat('en-US', {
@@ -166,22 +160,23 @@ const ControlTabs: React.FC<{
 
 // Summary stats component
 const SummaryStats: React.FC<{
-  totalWeekTokens: number;
-  totalWeekCost: number;
+  totalTokens: number;
+  totalCost: number;
   avgDailyTokens: number;
   avgDailyCost: number;
-}> = ({ totalWeekTokens, totalWeekCost, avgDailyTokens, avgDailyCost }) => (
+  timeRangeLabel: string;
+}> = ({ totalTokens, totalCost, avgDailyTokens, avgDailyCost, timeRangeLabel }) => (
   <div className="grid grid-cols-4 gap-3">
     <Card className="bg-neutral-900/50 border-neutral-800">
       <CardContent className="p-3 text-center">
-        <div className="text-xl font-bold text-white mb-1">{formatNumber(totalWeekTokens)}</div>
-        <div className="text-xs text-neutral-400">Total Tokens (7d)</div>
+        <div className="text-xl font-bold text-white mb-1">{formatNumber(totalTokens)}</div>
+        <div className="text-xs text-neutral-400">Total Tokens ({timeRangeLabel})</div>
       </CardContent>
     </Card>
     <Card className="bg-neutral-900/50 border-neutral-800">
       <CardContent className="p-3 text-center">
-        <div className="text-xl font-bold text-white mb-1">{formatCurrency(totalWeekCost)}</div>
-        <div className="text-xs text-neutral-400">Total Cost (7d)</div>
+        <div className="text-xl font-bold text-white mb-1">{formatCurrency(totalCost)}</div>
+        <div className="text-xs text-neutral-400">Total Cost ({timeRangeLabel})</div>
       </CardContent>
     </Card>
     <Card className="bg-neutral-900/50 border-neutral-800">
@@ -552,10 +547,13 @@ export const Analytics: React.FC<AnalyticsProps> = ({ stats }) => {
   const chartData = useChartData(stats, timeRange);
   const modelBreakdownData = useModelBreakdownData(stats);
 
-  const totalWeekTokens = stats.thisWeek.reduce((sum, day) => sum + day.totalTokens, 0);
-  const totalWeekCost = stats.thisWeek.reduce((sum, day) => sum + day.totalCost, 0);
-  const avgDailyTokens = totalWeekTokens / 7;
-  const avgDailyCost = totalWeekCost / 7;
+  const summaryData = timeRange === '7d' ? stats.thisWeek : stats.thisMonth;
+  const summaryDays = timeRange === '7d' ? 7 : 30;
+  const timeRangeLabel = timeRange === '7d' ? '7d' : '30d';
+  const totalTokens = summaryData.reduce((sum, day) => sum + day.totalTokens, 0);
+  const totalCost = summaryData.reduce((sum, day) => sum + day.totalCost, 0);
+  const avgDailyTokens = totalTokens / summaryDays;
+  const avgDailyCost = totalCost / summaryDays;
 
   return (
     <TooltipProvider>
@@ -591,10 +589,11 @@ export const Analytics: React.FC<AnalyticsProps> = ({ stats }) => {
             />
 
             <SummaryStats
-              totalWeekTokens={totalWeekTokens}
-              totalWeekCost={totalWeekCost}
+              totalTokens={totalTokens}
+              totalCost={totalCost}
               avgDailyTokens={avgDailyTokens}
               avgDailyCost={avgDailyCost}
+              timeRangeLabel={timeRangeLabel}
             />
           </CardContent>
         </Card>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -600,7 +600,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ stats, status }) => {
             </div>
           </CardContent>
         </Card>
-
       </div>
     </TooltipProvider>
   );

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { formatCurrency, formatNumber } from '../lib/utils';
 import type { UsageStats } from '../types/usage';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
@@ -20,11 +21,6 @@ const ModelUsageItem = ({
   index: number;
 }) => {
   const percentage = totalTokens > 0 ? (modelData.tokens / totalTokens) * 100 : 0;
-  const formatNumber = (num: number) => {
-    if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
-    if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;
-    return num.toLocaleString();
-  };
 
   const getModelColor = (index: number) => {
     return index === 0 ? 'bg-purple-500' : index === 1 ? 'bg-blue-500' : 'bg-green-500';
@@ -59,22 +55,6 @@ const ModelUsageItem = ({
       </div>
     </div>
   );
-};
-
-// Helper for formatting numbers and currency
-const formatNumber = (num: number) => {
-  if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
-  if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;
-  return num.toLocaleString();
-};
-
-const formatCurrency = (amount: number) => {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(amount);
 };
 
 // Helper for getting status-related values
@@ -270,6 +250,27 @@ export const Dashboard: React.FC<DashboardProps> = ({ stats, status }) => {
                         : status === 'warning'
                           ? '70-90% of daily limit used'
                           : 'Less than 70% of daily limit used'}
+                    </p>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div>
+                    <CircularProgressChart
+                      percentage={stats.resetInfo.percentUntilReset}
+                      label="Cycle"
+                      subtitle={`${stats.resetInfo.daysSinceReset}d elapsed`}
+                      emoji="⏱"
+                      isTime
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="text-center">
+                    <p className="font-semibold">⏱ Billing Cycle</p>
+                    <p className="text-sm mt-1">
+                      {stats.resetInfo.daysSinceReset} of {stats.resetInfo.daysInCycle} days elapsed
                     </p>
                   </div>
                 </TooltipContent>
@@ -600,26 +601,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ stats, status }) => {
           </CardContent>
         </Card>
 
-        {/* Quick Actions */}
-        {/* <div className="glass-card p-4">
-        <h3 className="text-lg font-bold text-white mb-4">Quick Actions</h3>
-        
-        <div className="grid grid-cols-2 gap-3">
-          <button className="btn btn-ghost flex items-center justify-center gap-2 py-3">
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-            </svg>
-            View Analytics
-          </button>
-          
-          <button className="btn btn-ghost flex items-center justify-center gap-2 py-3">
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-            </svg>
-            Export Data
-          </button>
-        </div>
-      </div> */}
       </div>
     </TooltipProvider>
   );

--- a/src/components/NavigationTabs.tsx
+++ b/src/components/NavigationTabs.tsx
@@ -20,6 +20,18 @@ const DashboardIcon = () => (
   </svg>
 );
 
+const LiveIcon = () => (
+  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <title>Live</title>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.5}
+      d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+    />
+  </svg>
+);
+
 const AnalyticsIcon = () => (
   <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
     <title>Analytics</title>
@@ -61,6 +73,12 @@ const tabs = [
     description: 'Overview and quick stats',
   },
   {
+    id: 'live' as ViewType,
+    name: 'Live',
+    icon: LiveIcon,
+    description: 'Real-time usage monitoring',
+  },
+  {
     id: 'analytics' as ViewType,
     name: 'Analytics',
     icon: AnalyticsIcon,
@@ -91,7 +109,7 @@ export const NavigationTabs: React.FC<NavigationTabsProps> = ({
       onValueChange={(value) => onNavigate(value as ViewType)}
       className={`${className} w-full`}
     >
-      <TabsList className="grid w-full grid-cols-4 gap-1">
+      <TabsList className="grid w-full grid-cols-5 gap-1">
         {tabs.map((tab) => {
           const IconComponent = tab.icon;
           return (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,20 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatNumber(num: number): string {
+  if (!num || Number.isNaN(num)) return '0';
+  if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
+  if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;
+  return num.toLocaleString();
+}
+
+export function formatCurrency(amount: number): string {
+  if (!amount || Number.isNaN(amount)) return '$0.00';
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}

--- a/src/services/ccusageService.ts
+++ b/src/services/ccusageService.ts
@@ -31,16 +31,6 @@ interface DailyDataEntry {
   modelBreakdowns: ModelBreakdown[];
 }
 
-interface UsageDataItem {
-  date: string;
-  inputTokens?: number;
-  outputTokens?: number;
-  cacheCreationTokens?: number;
-  totalCost?: number;
-  cost?: number;
-  modelBreakdowns?: ModelBreakdown[];
-}
-
 // Define SessionBlock interface matching ccusage package structure
 interface LoadedUsageEntry {
   timestamp: Date;
@@ -505,9 +495,26 @@ export class CCUsageService {
       average7d,
       trend,
       trendPercent: Math.round(trendPercent * 10) / 10,
-      peakHour: 14, // Simplified for now
+      peakHour: this.calculatePeakHourFromBlocks(blocks),
       isAccelerating: trend === 'increasing' && trendPercent > 20,
     };
+  }
+
+  private calculatePeakHourFromBlocks(blocks: SessionBlock[]): number {
+    const hourBuckets = new Array(24).fill(0);
+    for (const block of blocks) {
+      if (block.isGap) continue;
+      for (const entry of block.entries) {
+        const hour = new Date(entry.timestamp).getHours();
+        const tokens =
+          entry.usage.inputTokens +
+          entry.usage.outputTokens +
+          entry.usage.cacheCreationInputTokens +
+          entry.usage.cacheReadInputTokens;
+        hourBuckets[hour] += tokens;
+      }
+    }
+    return hourBuckets.indexOf(Math.max(...hourBuckets));
   }
 
   private getEmptyDailyUsage(): DailyUsage {
@@ -673,89 +680,6 @@ export class CCUsageService {
     }
   }
 
-  private calculatePredictedDepletion(
-    tokensUsed: number,
-    tokenLimit: number,
-    burnRate: number
-  ): string | null {
-    if (burnRate <= 0) return null;
-
-    const tokensRemaining = tokenLimit - tokensUsed;
-    if (tokensRemaining <= 0) return 'Depleted';
-
-    const hoursRemaining = tokensRemaining / burnRate;
-    const depletionDate = new Date(Date.now() + hoursRemaining * 60 * 60 * 1000);
-
-    return depletionDate.toISOString();
-  }
-
-  private groupByModel(data: UsageDataItem[]): { [key: string]: { tokens: number; cost: number } } {
-    const models: { [key: string]: { tokens: number; cost: number } } = {};
-
-    for (const item of data) {
-      this.processItemModelBreakdowns(item, models);
-    }
-
-    return models;
-  }
-
-  private processItemModelBreakdowns(
-    item: UsageDataItem,
-    models: { [key: string]: { tokens: number; cost: number } }
-  ): void {
-    if (!item.modelBreakdowns || !Array.isArray(item.modelBreakdowns)) {
-      return;
-    }
-
-    for (const breakdown of item.modelBreakdowns) {
-      this.aggregateModelData(breakdown, models);
-    }
-  }
-
-  private aggregateModelData(
-    breakdown: ModelBreakdown,
-    models: { [key: string]: { tokens: number; cost: number } }
-  ): void {
-    const modelName = breakdown.modelName || 'unknown';
-    if (!models[modelName]) {
-      models[modelName] = { tokens: 0, cost: 0 };
-    }
-    models[modelName].tokens +=
-      (breakdown.inputTokens || 0) +
-      (breakdown.outputTokens || 0) +
-      (breakdown.cacheCreationTokens || 0);
-    models[modelName].cost += breakdown.cost || 0;
-  }
-
-  private groupByDay(data: UsageDataItem[], days: number): DailyUsage[] {
-    const result: DailyUsage[] = [];
-    const now = new Date();
-
-    for (let i = 0; i < days; i++) {
-      const date = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
-      const dateStr = date.toISOString().split('T')[0];
-
-      const dayData = data.filter((item) => item.date === dateStr);
-      const totalTokens = dayData.reduce((sum, item) => {
-        return (
-          sum + (item.inputTokens || 0) + (item.outputTokens || 0) + (item.cacheCreationTokens || 0)
-        );
-      }, 0);
-      const totalCost = dayData.reduce((sum, item) => {
-        return sum + (item.totalCost || item.cost || 0);
-      }, 0);
-
-      result.push({
-        date: dateStr,
-        totalTokens,
-        totalCost,
-        models: this.groupByModel(dayData),
-      });
-    }
-
-    return result.reverse();
-  }
-
   private getUsageStatus(percentageUsed: number): 'safe' | 'warning' | 'critical' {
     if (percentageUsed >= 90) return 'critical';
     if (percentageUsed >= 70) return 'warning';
@@ -816,73 +740,6 @@ export class CCUsageService {
   }
 
   /**
-   * Calculate burn rate from daily data (for legacy compatibility)
-   */
-  private calculateBurnRate(data: UsageDataItem[]): number {
-    const last24Hours = data.filter((item) => {
-      const itemDate = new Date(item.date);
-      const now = new Date();
-      const hoursDiff = (now.getTime() - itemDate.getTime()) / (1000 * 60 * 60);
-      return hoursDiff <= 24;
-    });
-
-    const totalTokens = last24Hours.reduce((sum, item) => {
-      return (
-        sum + (item.inputTokens || 0) + (item.outputTokens || 0) + (item.cacheCreationTokens || 0)
-      );
-    }, 0);
-    return Math.round(totalTokens / 24); // tokens per hour
-  }
-
-  /**
-   * Calculate enhanced velocity information based on Python implementation
-   */
-  private calculateVelocityInfo(data: UsageDataItem[]): VelocityInfo {
-    const now = new Date();
-
-    // Current burn rate (last 24 hours)
-    const current = this.calculateBurnRate(data);
-
-    // 24-hour average
-    const last24Hours = data.filter((item) => {
-      const itemDate = new Date(item.date);
-      const hoursDiff = (now.getTime() - itemDate.getTime()) / (1000 * 60 * 60);
-      return hoursDiff <= 24;
-    });
-    const average24h = this.calculateAverageBurnRate(last24Hours);
-
-    // 7-day average
-    const last7Days = data.filter((item) => {
-      const itemDate = new Date(item.date);
-      const daysDiff = (now.getTime() - itemDate.getTime()) / (1000 * 60 * 60 * 24);
-      return daysDiff <= 7;
-    });
-    const average7d = this.calculateAverageBurnRate(last7Days);
-
-    // Trend analysis
-    const trendPercent = average24h > 0 ? ((current - average24h) / average24h) * 100 : 0;
-    let trend: 'increasing' | 'decreasing' | 'stable' = 'stable';
-
-    if (Math.abs(trendPercent) > 15) {
-      // 15% threshold for trend detection
-      trend = trendPercent > 0 ? 'increasing' : 'decreasing';
-    }
-
-    // Peak hour analysis
-    const peakHour = this.calculatePeakUsageHour(data);
-
-    return {
-      current,
-      average24h,
-      average7d,
-      trend,
-      trendPercent: Math.round(trendPercent * 10) / 10,
-      peakHour,
-      isAccelerating: trend === 'increasing' && trendPercent > 20,
-    };
-  }
-
-  /**
    * Calculate prediction information with confidence levels
    */
   private calculatePredictionInfo(
@@ -936,30 +793,6 @@ export class CCUsageService {
     };
   }
 
-  /**
-   * Calculate average burn rate for a given dataset
-   */
-  private calculateAverageBurnRate(data: UsageDataItem[]): number {
-    if (data.length === 0) return 0;
-
-    const totalTokens = data.reduce((sum, item) => {
-      return (
-        sum + (item.inputTokens || 0) + (item.outputTokens || 0) + (item.cacheCreationTokens || 0)
-      );
-    }, 0);
-
-    const totalHours = data.length * 24; // Assuming daily data points
-    return totalHours > 0 ? Math.round(totalTokens / totalHours) : 0;
-  }
-
-  /**
-   * Calculate peak usage hour (simplified version)
-   */
-  private calculatePeakUsageHour(data: UsageDataItem[]): number {
-    // Simplified: assume afternoon hours are peak usage
-    // In a real implementation, this would analyze hourly usage patterns
-    return 14; // 2 PM
-  }
 
   /**
    * Get actual next reset time based on active session block end time

--- a/src/services/ccusageService.ts
+++ b/src/services/ccusageService.ts
@@ -793,7 +793,6 @@ export class CCUsageService {
     };
   }
 
-
   /**
    * Get actual next reset time based on active session block end time
    */

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -70,47 +70,6 @@ export interface UsageStats {
   tokensRemaining: number;
   percentageUsed: number;
   sessionTracking?: SessionTracking; // 5-hour rolling session tracking
-  // Enhanced features
-  enhancedResetInfo?: {
-    nextResetTime: string;
-    timeUntilReset: number;
-    resetType: 'interval' | 'monthly';
-    resetSchedule: number[];
-    formattedTimeUntilReset: string;
-    cycleProgress: number;
-    isInCriticalPeriod: boolean;
-  };
-  advancedBurnRate?: {
-    current: number;
-    hourly: number;
-    trend: {
-      direction: 'increasing' | 'decreasing' | 'stable';
-      percentage: number;
-    };
-    velocity: {
-      classification: 'slow' | 'normal' | 'fast' | 'very_fast';
-      emoji: string;
-    };
-    confidence: number;
-  };
-  planManager?: {
-    currentPlan: 'Pro' | 'Max5' | 'Max20' | 'Custom';
-    autoSwitchEnabled: boolean;
-    detectedPlan: 'Pro' | 'Max5' | 'Max20' | 'Custom';
-    confidence: number;
-    lastSwitch?: {
-      timestamp: string;
-      fromPlan: string;
-      toPlan: string;
-      trigger: string;
-    };
-  };
-  limitDetection?: {
-    detectedLimit: number;
-    confidence: number;
-    detectionMethod: string;
-    shouldUpdate: boolean;
-  };
 }
 
 export interface UserConfiguration {


### PR DESCRIPTION
## Summary

- **Live Monitoring tab was broken**: the component was imported but never rendered and had no nav tab — now wired up with a Live tab entry and render case
- **Analytics summary stats ignored time range**: always read from `thisWeek` regardless of the 7d/30d toggle — now derives data from the selected range and updates card labels accordingly
- **Dashboard had a ghost grid**: `grid-cols-2` with only one `CircularProgressChart` — restored the billing cycle chart using `resetInfo.percentUntilReset` / `daysSinceReset`
- **Peak hour was hardcoded to 14**: replaced with `calculatePeakHourFromBlocks()` that buckets token counts by hour-of-day across all block entries
- **`formatNumber`/`formatCurrency` duplicated** across Dashboard and Analytics — moved to `src/lib/utils.ts` and imported from there
- **9 dead legacy service methods removed** (`calculateBurnRate`, `calculateVelocityInfo`, `calculateAverageBurnRate`, `calculatePeakUsageHour`, `groupByDay`, `groupByModel`, `processItemModelBreakdowns`, `aggregateModelData`, `calculatePredictedDepletion`) along with `UsageDataItem` interface
- **4 never-populated `UsageStats` fields removed** (`enhancedResetInfo`, `advancedBurnRate`, `planManager`, `limitDetection`)
- **Commented-out Quick Actions block removed** from Dashboard

## Test plan

- [ ] `npm run type-check` passes with zero errors
- [ ] `npm run lint` passes clean
- [ ] All 5 nav tabs visible and clickable (Dashboard, Live, Analytics, Terminal, Settings)
- [ ] Clicking "Live" renders the live monitoring view
- [ ] Analytics: toggle 7d ↔ 30d — summary cards update values and labels ("Total Tokens (7d)" / "Total Tokens (30d)")
- [ ] Dashboard: both circular charts render side-by-side (Tokens + Cycle)
- [ ] Analytics Performance Metrics "Peak Hour" reflects actual usage patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)