### PR TITLE
Swift CI + release pipeline, make Swift primary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,44 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  swift-build:
+    runs-on: macos-15
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Select Xcode 16.4
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '16.4'
+
+    - name: Print Swift version
+      run: swift --version
+
+    - name: Build Swift package (release)
+      working-directory: swift
+      run: swift build -c release
+
+    - name: Assemble CCSeva.app
+      working-directory: swift
+      run: ./scripts/build-app.sh
+
+    - name: Verify app bundle and resources
+      working-directory: swift
+      run: |
+        test -d dist/CCSeva.app
+        test -d dist/CCSeva.app/Contents/Resources/CCSeva_CCSeva.bundle
+
+    - name: Smoke test (--diagnose)
+      working-directory: swift
+      run: .build/release/CCSeva --diagnose
+
+    - name: Upload app bundle
+      uses: actions/upload-artifact@v4
+      with:
+        name: CCSeva-app-debug
+        path: swift/dist/CCSeva.app
+
   security:
     runs-on: ubuntu-latest
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,127 +5,150 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
-    runs-on: macos-latest
-    
+    runs-on: macos-15
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Use Node.js 20.x
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20.x
-        cache: 'npm'
-    
-    - name: Install dependencies
-      run: npm ci
-    
-    - name: Run linting
-      run: npm run lint
-       
-    - name: Type check
-      run: npx tsc --noEmit
 
-    - name: Build distributables
-      run: npm run dist:mac
-      timeout-minutes: 30
+    - name: Select Xcode 16.4
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '16.4'
+
+    - name: Detect signing secrets
+      run: echo "HAS_SIGNING=${{ secrets.MACOS_CERTIFICATE_BASE64 != '' }}" >> "$GITHUB_ENV"
+
+    - name: Build Swift binary
+      working-directory: swift
+      run: swift build -c release
+
+    - name: Assemble CCSeva.app
+      working-directory: swift
+      run: ./scripts/build-app.sh
+
+    - name: Import Developer ID certificate
+      if: ${{ env.HAS_SIGNING == 'true' }}
       env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        # Code signing and notarization
-        CSC_LINK: ${{ secrets.CSC_LINK }}
-        CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-        APPLE_ID: ${{ secrets.APPLE_ID }}
-        APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        MACOS_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
+        MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      run: |
+        set -euo pipefail
+        KEYCHAIN_PATH="$RUNNER_TEMP/ccseva-signing.keychain-db"
+        KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+        CERT_PATH="$RUNNER_TEMP/developer-id.p12"
+
+        echo "$MACOS_CERTIFICATE_BASE64" | base64 --decode > "$CERT_PATH"
+
+        security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security import "$CERT_PATH" -P "$MACOS_CERTIFICATE_PASSWORD" \
+          -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+        security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+        rm -f "$CERT_PATH"
+        echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+    - name: Codesign with Developer ID
+      if: ${{ env.HAS_SIGNING == 'true' }}
+      env:
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-    
-    - name: Verify build artifacts
       run: |
-        echo "Verifying build artifacts..."
-        ls -la release/
-        if [ ! -f release/*.dmg ]; then
-          echo "ERROR: No DMG file found!"
-          echo "Build artifacts:"
-          find release/ -type f -name "*" || echo "No release directory found"
-          exit 1
-        fi
-        echo "✅ DMG file found"
-        
-    - name: Show notarization status
-      if: success() || failure()
+        set -euo pipefail
+        IDENTITY="Developer ID Application: ${{ secrets.APPLE_DEVELOPER_NAME }} ($APPLE_TEAM_ID)"
+        codesign --force --options runtime --timestamp \
+          --sign "$IDENTITY" swift/dist/CCSeva.app
+        codesign --verify --deep --strict --verbose=2 swift/dist/CCSeva.app
+
+    - name: Package artifacts (pre-notarization)
       run: |
-        echo "Build completed. Checking for any notarization logs..."
-        if [ -d "release/" ]; then
-          echo "Contents of release directory:"
-          ls -la release/
-        fi
-        
+        set -euo pipefail
+        ZIP="CCSeva-${{ github.ref_name }}-arm64.zip"
+        ditto -c -k --keepParent swift/dist/CCSeva.app "$ZIP"
+        echo "ARTIFACT_ZIP=$ZIP" >> "$GITHUB_ENV"
+
+    - name: Notarize and staple
+      if: ${{ env.HAS_SIGNING == 'true' }}
+      env:
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+      run: |
+        set -euo pipefail
+        xcrun notarytool submit "$ARTIFACT_ZIP" \
+          --apple-id "$APPLE_ID" \
+          --team-id "$APPLE_TEAM_ID" \
+          --password "$APPLE_APP_PASSWORD" \
+          --wait
+        xcrun stapler staple swift/dist/CCSeva.app
+
+    - name: Re-package stapled app
+      if: ${{ env.HAS_SIGNING == 'true' }}
+      run: |
+        set -euo pipefail
+        rm -f "$ARTIFACT_ZIP"
+        ditto -c -k --keepParent swift/dist/CCSeva.app "$ARTIFACT_ZIP"
+
+    - name: Create DMG
+      run: |
+        set -euo pipefail
+        DMG="CCSeva-${{ github.ref_name }}-arm64.dmg"
+        hdiutil create -volname CCSeva -srcfolder swift/dist/CCSeva.app -ov -format UDZO "$DMG"
+        echo "ARTIFACT_DMG=$DMG" >> "$GITHUB_ENV"
+
+    - name: Compose release body
+      run: |
+        set -euo pipefail
+        {
+          echo "## CCSeva ${{ github.ref_name }} (native Swift app)"
+          echo ""
+          echo "This is the native Swift macOS menu bar app (Apple Silicon / arm64)."
+          echo ""
+          echo "### Install"
+          echo ""
+          echo "Download \`${ARTIFACT_DMG}\` (or \`${ARTIFACT_ZIP}\`), then drag **CCSeva** to your Applications folder."
+          echo ""
+          if [ "${HAS_SIGNING}" = "true" ]; then
+            echo "This build is signed with a Developer ID and notarized by Apple."
+          else
+            echo "> **Note:** This build is **not** notarized. On first launch, right-click **CCSeva** and choose **Open**, or remove the quarantine flag with:"
+            echo ">"
+            echo "> \`\`\`sh"
+            echo "> xattr -dr com.apple.quarantine /Applications/CCSeva.app"
+            echo "> \`\`\`"
+          fi
+          echo ""
+          echo "### Requirements"
+          echo ""
+          echo "- macOS 14 (Sonoma) or later, Apple Silicon"
+        } > release-body.md
+        echo "RELEASE_BODY_FILE=release-body.md" >> "$GITHUB_ENV"
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: distributables-${{ github.ref_name }}
+        name: ccseva-${{ github.ref_name }}
         path: |
-          release/*.dmg
-          release/*.yml
-          release/latest-mac.yml
-    
+          CCSeva-${{ github.ref_name }}-arm64.zip
+          CCSeva-${{ github.ref_name }}-arm64.dmg
+
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |
-          release/*.dmg
+          CCSeva-${{ github.ref_name }}-arm64.zip
+          CCSeva-${{ github.ref_name }}-arm64.dmg
         draft: false
-        prerelease: contains(github.ref, 'beta') || contains(github.ref, 'alpha') || contains(github.ref, 'rc')
+        prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') || contains(github.ref, 'rc') }}
         generate_release_notes: true
         name: CCSeva ${{ github.ref_name }}
-        body: |
-          ## 🚀 CCSeva ${{ github.ref_name }}
-          
-          A beautiful macOS menu bar app for real-time Claude Code usage tracking with live token monitoring, usage analytics, and smart notifications.
-          
-          ### 📥 Download Instructions
-          
-          **Choose the right version for your Mac:**
-          
-          - **🍎 Apple Silicon (M1/M2/M3/M4)**: Download `CCSeva-${{ github.ref_name }}-arm64.dmg`
-          - **💻 Intel Macs**: Download `CCSeva-${{ github.ref_name }}.dmg`
-          
-          > **Not sure which Mac you have?** Go to **Apple Menu → About This Mac**. If you see "Apple M1", "Apple M2", or "Apple M3", choose the ARM64 version. If you see "Intel", choose the Intel version.
-          
-          ### 📦 Installation
-          
-          1. Download the appropriate `.dmg` file from the assets below
-          2. Double-click the downloaded DMG file to mount it
-          3. Drag **CCSeva** to your **Applications** folder
-          4. Launch CCSeva from Applications or Spotlight
-          5. Grant necessary permissions when prompted (menu bar access)
-          
-          ### ✨ Features
-          
-          - **Real-time Usage Monitoring**: Live token consumption tracking
-          - **Smart Plan Detection**: Automatically detects your Claude plan (Pro/Max5/Max20)
-          - **Usage Analytics**: 7-day usage trends and burn rate calculations
-          - **Native Notifications**: Intelligent alerts at 70% and 90% usage thresholds
-          - **Beautiful Interface**: Clean, modern design with glass morphism effects
-          - **Menu Bar Integration**: Unobtrusive menu bar presence with percentage display
-          
-          ### 🔧 Requirements
-          
-          - **macOS 10.15** (Catalina) or later
-          - **Claude Code CLI** installed and configured
-          - Valid Claude API credentials in `~/.claude` directory
-          
-          ### 🛠️ Technical Details
-          
-          - Built with Electron and React
-          - Uses the `ccusage` npm package for data fetching
-          - Code-signed and notarized for security
-          - Supports both Intel and Apple Silicon architectures
-          
-          ---
-          
-          💡 **Need help?** [Open an issue](https://github.com/Iamshankhadeep/ccseva/issues) or check the [documentation](https://github.com/Iamshankhadeep/ccseva#readme).
-          
+        body_path: release-body.md
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 [![GitHub release](https://img.shields.io/github/release/Iamshankhadeep/ccseva.svg)](https://github.com/Iamshankhadeep/ccseva/releases)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/Iamshankhadeep/ccseva/ci.yml?branch=main)](https://github.com/Iamshankhadeep/ccseva/actions)
 [![Downloads](https://img.shields.io/github/downloads/Iamshankhadeep/ccseva/total.svg)](https://github.com/Iamshankhadeep/ccseva/releases)
-[![macOS](https://img.shields.io/badge/macOS-10.15%2B-blue)](https://github.com/Iamshankhadeep/ccseva)
+[![macOS](https://img.shields.io/badge/macOS-14.0%2B-blue)](https://github.com/Iamshankhadeep/ccseva)
 
-A beautiful macOS menu bar app for tracking your Claude Code usage in real-time. Monitor token consumption, costs, and usage patterns with an elegant interface.
+A lightweight, **native Swift** macOS menu bar app for tracking your Claude Code usage in real-time. Monitor token consumption, costs, session blocks, and server-side limits with an elegant native interface.
 
-> **New: native Swift app.** CCSeva is being rewritten as a lightweight native Swift menu bar app (no Electron, ~a few MB instead of hundreds, near-zero idle overhead). It parses `~/.claude` data directly, tracks 5-hour session blocks and weekly usage, and shows **real server-side limit gauges** (5-hour + weekly utilization with reset countdowns and predicted cutoff time). See [`swift/README.md`](swift/README.md) to build and try it. The Electron app remains fully supported in the meantime.
+CCSeva runs as a menu-bar-only app built on `NSStatusItem` + `NSPopover` + SwiftUI. It's roughly **3 MB installed with zero runtime dependencies** — no Electron, no Node, near-zero idle overhead. It parses your `~/.claude` transcripts directly and shows **real server-truth limit gauges** (5-hour + weekly utilization with reset countdowns and a predicted cutoff time). The app lives in [`swift/`](swift/).
+
+> **Note:** The original Electron app is now **legacy** and being phased out in favor of this native Swift app. It is still present in the repository root (see [Legacy: Electron app](#legacy-electron-app) below).
 
 ## Screenshots
 
@@ -18,26 +20,73 @@ A beautiful macOS menu bar app for tracking your Claude Code usage in real-time.
 
 ## Features
 
-- **Real-time monitoring** - Live token usage tracking with 30-second updates
-- **5-hour session blocks** - Current block usage, burn rate, projection, and reset countdown
-- **Weekly usage** - Week-by-week token and cost history (Monday weeks, matching Claude's weekly limits)
-- **Menu bar integration** - Percentage indicator with color-coded status
-- **Smart plan detection** - Auto-detects Pro/Max5/Max20/Custom plans
-- **Usage analytics** - Daily charts, model breakdowns, and trend analysis
-- **Smart notifications** - Alerts at 70% and 90% thresholds with cooldown
-- **Cost tracking** - Daily cost estimates and burn rate calculations
-- **Beautiful UI** - Gradient design with glass morphism effects
-
-The native Swift app (in [`swift/`](swift/)) adds server-truth limit gauges: it reads the same OAuth usage endpoint Claude Code's `/usage` command uses, so the 5-hour and weekly percentages match what Anthropic actually enforces — including usage from other devices.
+- **Live menu bar usage** — usage percentage shown right in the menu bar with color-coded status
+- **5-hour session blocks** — current block tokens, burn rate, end-of-window projection, and reset countdown
+- **Weekly usage history** — week-by-week token and cost rollups (matching Claude's weekly limits)
+- **Server-truth limit gauges** — reads Claude Code's OAuth usage endpoint for real 5-hour and weekly utilization (including usage from other devices) plus a predicted cutoff time, with automatic local-estimation fallback when the endpoint is unavailable
+- **Per-model & per-project cost breakdown** — see where your tokens and dollars go
+- **Five tabs** — Dashboard, Live, Analytics (Swift Charts), Terminal, and Settings
+- **Native notifications** — alerts at 70% and 90% thresholds with a cooldown, only firing when status worsens
+- **Launch at login** — optional toggle in Settings
+- **Native JSONL parsing** — reads `~/.claude/projects/**/*.jsonl` directly with incremental scanning and dedup
+- **Warm Fira Code UI** — clean, monospaced native styling
 
 ## Installation
 
 ### Download (Recommended)
+
 Download the latest release from [GitHub Releases](https://github.com/Iamshankhadeep/ccseva/releases):
-- **macOS (Apple Silicon)**: `CCSeva-darwin-arm64.dmg`
-- **macOS (Intel)**: `CCSeva-darwin-x64.dmg`
+
+- **macOS (Apple Silicon)**: `CCSeva-<version>-arm64.zip` or `CCSeva-<version>-arm64.dmg`
+
+> **First launch (unsigned build):** Until a Developer ID certificate is configured, release artifacts are ad-hoc signed. The first time you open the app, macOS Gatekeeper will block it. Either **right-click `CCSeva.app` → Open** (then confirm), or remove the quarantine attribute:
+> ```bash
+> xattr -dr com.apple.quarantine CCSeva.app
+> ```
 
 ### Build from Source
+
+Requires **Xcode 16.4 / Swift 6.1** and **macOS 14+** (Sonoma).
+
+```bash
+git clone https://github.com/Iamshankhadeep/ccseva.git
+cd ccseva/swift
+./scripts/build-app.sh        # release build → dist/CCSeva.app (ad-hoc codesigned)
+mv dist/CCSeva.app /Applications/
+```
+
+See [`swift/README.md`](swift/README.md) for full build, architecture, and data-pipeline details.
+
+## Usage
+
+1. **Launch** — CCSeva appears in your menu bar, showing your current usage percentage.
+2. **Left-click** — opens the popover with the Dashboard, Live, Analytics, Terminal, and Settings tabs.
+3. **Right-click** — access Refresh and Quit.
+4. **Launch at Login** — enable it in the Settings tab so CCSeva starts automatically.
+
+The app automatically detects your Claude Code configuration from the `~/.claude` directory and refreshes on file changes (with a periodic fallback poll).
+
+## Requirements
+
+- macOS 14+ (Sonoma)
+- For building from source: Xcode 16.4 / Swift 6.1
+- Claude Code installed and configured (valid `~/.claude` data)
+
+## Tech Stack
+
+- Swift 6.1 + SwiftUI + AppKit (`NSStatusItem` / `NSPopover`)
+- Swift Charts for analytics visualizations
+- Native, ccusage-compatible JSONL parsing (incremental scan + dedup) and 5-hour block computation
+- No Electron, no Node, and no external runtime dependencies — a single ~3 MB app bundle
+
+## Legacy: Electron app
+
+> **The Electron app is being phased out** in favor of the native Swift app above. It remains in the repository root (`main.ts`, `preload.ts`, and `src/`) for now, but new development targets the Swift app.
+
+The original CCSeva was a macOS menu bar app built with Electron 36, React 19, TypeScript 5, Tailwind CSS 3, and Radix UI, using the [`ccusage`](https://github.com/ryoppippi/ccusage) package for data integration.
+
+### Build & run
+
 ```bash
 git clone https://github.com/Iamshankhadeep/ccseva.git
 cd ccseva
@@ -47,29 +96,12 @@ npm start
 ```
 
 ### Development
+
 ```bash
-npm run electron-dev  # Hot reload development
+npm run electron-dev   # hot reload development
 ```
 
-## Usage
-
-1. **Launch** - CCSeva appears in your menu bar
-2. **Click** - View detailed usage statistics
-3. **Right-click** - Access refresh and quit options
-
-The app automatically detects your Claude Code configuration from `~/.claude` directory and updates every 30 seconds.
-
-## Requirements
-
-- macOS 10.15+
-- Node.js 18+ (for building from source)
-- Claude Code CLI installed and configured
-
-## Tech Stack
-
-- Electron 36 + React 19 + TypeScript 5
-- Tailwind CSS 3 + Radix UI components
-- ccusage package for data integration
+The Electron app requires Node.js 18+ to build and runs on macOS 10.15+.
 
 ## License
 
@@ -77,8 +109,8 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ## Credits
 
-Built with ❤️ using [Electron](https://electronjs.org), [React](https://reactjs.org), [Tailwind CSS](https://tailwindcss.com), and [ccusage](https://github.com/ryoppippi/ccusage).
+Built with ❤️ using [Swift](https://swift.org), [SwiftUI](https://developer.apple.com/xcode/swiftui/), and [ccusage](https://github.com/ryoppippi/ccusage) (for the usage data format and 5-hour block algorithm). The legacy app additionally uses [Electron](https://electronjs.org), [React](https://reactjs.org), and [Tailwind CSS](https://tailwindcss.com).
 
 ---
 
-**Note**: This is an unofficial tool for tracking Claude Code usage. Requires valid Claude Code installation and configuration.
+**Note**: This is an unofficial tool for tracking Claude Code usage. Requires a valid Claude Code installation and configuration.


### PR DESCRIPTION
## Summary

Follow-up to #35. Wires the native Swift app into CI and releases and makes it the primary app in the README — **without removing the Electron app yet** (that's the final phase). After this, GitHub Actions actually builds/ships the Swift app.

## Changes

1. **`ci`: build + smoke-test the Swift app** — new `swift-build` job (macos-15, Xcode 16.4) that runs `swift build -c release`, assembles the `.app` via `scripts/build-app.sh`, asserts the bundle + Fira Code resource bundle exist, runs `--diagnose` as a headless smoke test (exits 0 even with no `~/.claude` data), and uploads the built app as an artifact. Existing `test`/`security` jobs untouched.

2. **`ci`: release the Swift app instead of the Electron DMG** — `release.yml` now builds the `.app`, zips it (`ditto`) and builds a DMG (`hdiutil`), and publishes both to the GitHub Release. **Developer ID signing + notarization are fully optional**: every signing step is guarded on `MACOS_CERTIFICATE_BASE64` being non-empty, so with no secrets configured the workflow ships an ad-hoc-signed artifact (unsigned-install caveat in the release notes) and never hard-fails. Preserves the `v*` tag trigger, prerelease detection, and `generate_release_notes`; adds `permissions: contents: write`.

3. **`docs`: Swift primary in README** — leads with the native Swift app, install via Releases or `swift/scripts/build-app.sh`, macOS badge → 14.0+, and the Electron instructions moved to a "Legacy: Electron app" section.

## Optional: notarization secrets

The release workflow ships an unsigned artifact out of the box. To get a signed + notarized build, add these repo secrets (all optional; absence skips signing):
`MACOS_CERTIFICATE_BASE64` (master switch), `MACOS_CERTIFICATE_PASSWORD`, `APPLE_DEVELOPER_NAME`, `APPLE_TEAM_ID`, `APPLE_ID`, `APPLE_APP_PASSWORD`.

## Verification

- Both workflow YAMLs validated (`yaml.safe_load`); `ci.yml` jobs = `test`, `swift-build`, `security`.
- Locally ran the exact CI commands: `swift build -c release` → `build-app.sh` → bundle + resource-bundle asserts pass → `--diagnose` exits 0.
- README checked: macOS 14.0+ badge, Legacy Electron section present.

## Not in this PR

Deleting the Electron app (`main.ts`, `preload.ts`, `src/`, webpack/tailwind/postcss configs, `electron-builder.json`, Electron deps) is the final phase — deferred so this PR is reviewable and CI/releases keep working throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)