### PR TITLE
feat: pair CCSeva with claudecode.directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
       working-directory: swift
       run: swift build -c release
 
+    - name: Run Swift tests
+      working-directory: swift
+      run: swift test
+
     - name: Assemble CCSeva.app
       working-directory: swift
       run: ./scripts/build-app.sh

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ See [`swift/README.md`](swift/README.md) for full build, architecture, and data-
 
 The app automatically detects your Claude Code configuration from the `~/.claude` directory and refreshes on file changes (with a periodic fallback poll).
 
+### Optional claudecode.directory sync
+
+Open **Settings → claudecode.directory → Connect with GitHub** to pair this Mac with your
+private usage dashboard. CCSeva opens a short-lived verification page in your browser and stores
+the resulting device credential in macOS Keychain. Connected Macs sync idempotent daily/model
+aggregates in the background and can be disconnected from either CCSeva or the website.
+
+Sync is local-first and opt-in. CCSeva uploads token totals, estimated cost, date, timezone,
+harness, provider, and model. It never uploads prompts, responses, transcript content, project
+names or paths, request IDs, API keys, or Claude OAuth credentials.
+
+For local integration testing, set `CCSEVA_DIRECTORY_URL` to the dynamic directory server URL.
+Production builds default to `https://claudecode.directory`.
+
 ## Requirements
 
 - macOS 14+ (Sonoma)

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "date-fns-tz": "^3.2.0",
         "lucide-react": "^0.523.0",
         "next-themes": "^0.4.6",
-        "postcss": "^8.5.6",
+        "postcss": "8.5.18",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "sonner": "^2.0.7",
@@ -7309,9 +7309,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.523.0",
     "next-themes": "^0.4.6",
-    "postcss": "^8.5.6",
+    "postcss": "8.5.18",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "sonner": "^2.0.7",

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -12,6 +12,11 @@ let package = Package(
             name: "CCSeva",
             path: "Sources/CCSeva",
             resources: [.process("Resources")]
-        )
+        ),
+        .testTarget(
+            name: "CCSevaTests",
+            dependencies: ["CCSeva"],
+            path: "Tests/CCSevaTests"
+        ),
     ]
 )

--- a/swift/README.md
+++ b/swift/README.md
@@ -43,6 +43,10 @@ Sources/CCSeva/
 │   ├── LimitsProvider.swift   # protocol + window types
 │   ├── OAuthLimitsProvider.swift  # api.anthropic.com/api/oauth/usage client
 │   └── Credentials.swift      # Keychain ("Claude Code-credentials") / file token
+├── Directory/
+│   ├── DirectoryClient.swift  # pairing + aggregate sync API client
+│   ├── DirectoryCredentialStore.swift # separate device credential Keychain item
+│   └── DirectoryIdentity.swift # stable installation ID + app/device metadata
 ├── Support/
 │   ├── Settings.swift         # ~/.ccseva/settings.json (shared with Electron app)
 │   ├── Notifier.swift         # UNUserNotificationCenter / osascript thresholds
@@ -111,6 +115,17 @@ the session limit at HH:mm" when the projection crosses 100% before the reset.
 percentage/cost/alternate, `menuBarCostSource` today/sessionWindow). Unknown keys are
 preserved on save, so the two apps can share the file. `refreshIntervalSeconds` is a
 Swift-app extension key.
+
+### Optional directory sync
+
+The Settings tab can pair the app with `claudecode.directory` through a short-lived
+browser verification code. The resulting device credential is stored under the separate
+Keychain service `com.iamshankhadeep.ccseva.directory`. After each local scan, CCSeva
+coalesces usage into day/model buckets and sends those aggregates after a short debounce.
+Uploads are replacement upserts, so rescanning the same transcript does not double count.
+
+Claude OAuth credentials and raw transcript data never enter the directory sync payload.
+Set `CCSEVA_DIRECTORY_URL` only when testing against a local or staging server.
 
 ### Notifications
 

--- a/swift/Sources/CCSeva/Data/Aggregator.swift
+++ b/swift/Sources/CCSeva/Data/Aggregator.swift
@@ -84,6 +84,7 @@ enum Aggregator {
         var weeklyMap: [Date: WeeklyUsage] = [:]
         var modelMap: [String: ModelUsage] = [:]
         var projectMap: [String: ProjectCost] = [:]
+        var syncMap: [String: UsageSyncBucket] = [:]
         var unknownModels = Set<String>()
         var maxBlockTokens = 0
 
@@ -93,6 +94,23 @@ enum Aggregator {
 
         for entry in entries {
             if !entry.priced { unknownModels.insert(entry.model) }
+
+            // Cloud sync is deliberately aggregated before leaving the scanner. The
+            // server receives daily/model totals, never individual requests or content.
+            let syncDateKey = dayFormatter.string(from: entry.timestamp)
+            let syncKey = "\(syncDateKey)\u{1F}\(entry.model)"
+            var syncBucket = syncMap[syncKey] ?? UsageSyncBucket(
+                bucketStart: calendar.startOfDay(for: entry.timestamp),
+                localDate: syncDateKey,
+                timezone: TimeZone.current.identifier,
+                harness: "claude-code",
+                provider: "anthropic",
+                model: entry.model
+            )
+            syncBucket.tokens.add(entry)
+            syncBucket.estimatedCostMicros += Int64((entry.costUSD * 1_000_000).rounded())
+            syncBucket.eventCount += 1
+            syncMap[syncKey] = syncBucket
 
             // Daily (local timezone), last 30 days.
             if entry.timestamp >= dailyCutoff {
@@ -144,6 +162,10 @@ enum Aggregator {
             weekly: weeklyMap.values.sorted { $0.weekStart < $1.weekStart },
             modelBreakdown: modelMap.values.sorted { $0.cost > $1.cost },
             projectsThisMonth: projectMap.values.sorted { $0.cost > $1.cost },
+            syncBuckets: syncMap.values.sorted {
+                if $0.bucketStart == $1.bucketStart { return $0.model < $1.model }
+                return $0.bucketStart < $1.bucketStart
+            },
             todayTokens: today?.tokens.total ?? 0,
             todayCost: today?.cost ?? 0,
             hasUnpricedModels: !unknownModels.isEmpty,

--- a/swift/Sources/CCSeva/Data/Models.swift
+++ b/swift/Sources/CCSeva/Data/Models.swift
@@ -20,7 +20,7 @@ struct UsageEntry {
 }
 
 /// Token sums broken down by type.
-struct TokenCounts {
+struct TokenCounts: Equatable {
     var input = 0
     var output = 0
     var cacheCreation = 0
@@ -131,6 +131,20 @@ struct ProjectCost: Identifiable {
     var id: String { name }
 }
 
+/// Privacy-preserving daily/model aggregate sent to claudecode.directory.
+/// It intentionally contains no transcript text, request IDs, or project paths.
+struct UsageSyncBucket: Equatable {
+    let bucketStart: Date
+    let localDate: String
+    let timezone: String
+    let harness: String
+    let provider: String
+    let model: String
+    var tokens = TokenCounts()
+    var estimatedCostMicros: Int64 = 0
+    var eventCount: Int = 0
+}
+
 /// Scan bookkeeping for diagnostics.
 struct ScanStats {
     var filesSeen = 0
@@ -155,6 +169,8 @@ struct UsageSnapshot {
     let modelBreakdown: [ModelUsage]
     /// Current-month per-project cost, sorted descending.
     let projectsThisMonth: [ProjectCost]
+    /// All locally available usage, bucketed by local day and model for optional cloud sync.
+    let syncBuckets: [UsageSyncBucket]
     let todayTokens: Int
     let todayCost: Double
     let hasUnpricedModels: Bool
@@ -165,7 +181,7 @@ struct UsageSnapshot {
     static let empty = UsageSnapshot(
         generatedAt: Date(), stats: ScanStats(), totalEntries: 0, blocks: [],
         activeBlock: nil, daily: [], weekly: [], modelBreakdown: [],
-        projectsThisMonth: [], todayTokens: 0, todayCost: 0,
+        projectsThisMonth: [], syncBuckets: [], todayTokens: 0, todayCost: 0,
         hasUnpricedModels: false, unknownModels: [], maxBlockTokens: 0
     )
 }

--- a/swift/Sources/CCSeva/Data/UsageStore.swift
+++ b/swift/Sources/CCSeva/Data/UsageStore.swift
@@ -12,6 +12,12 @@ enum LimitsState: Equatable {
     var isLive: Bool { self == .live }
 }
 
+enum DirectoryConnectionState: Equatable {
+    case disconnected
+    case pairing
+    case connected
+}
+
 /// Single source of truth for the app. Owns the scanner actor, the FSEvents
 /// watcher, the fallback/limits timers and all derived UI state.
 @MainActor
@@ -23,11 +29,19 @@ final class UsageStore: ObservableObject {
     @Published private(set) var isRefreshing = false
     @Published private(set) var lastRefreshAt: Date?
     @Published private(set) var settings: AppSettings
+    @Published private(set) var directoryState: DirectoryConnectionState = .disconnected
+    @Published private(set) var directoryCredential: DirectoryCredential?
+    @Published private(set) var directoryPairing: DirectoryPairing?
+    @Published private(set) var directoryLastSyncAt: Date?
+    @Published private(set) var directoryError: String?
+    @Published private(set) var isDirectorySyncing = false
 
     private let dataSource = UsageDataSource()
     private let limitsProvider: LimitsProvider
     private let notifier = Notifier()
     private let settingsManager = SettingsManager.shared
+    private let directoryClient = DirectoryClient()
+    private let directoryCredentialStore = DirectoryCredentialStore()
 
     private var watcher: FileWatcher?
     private var fallbackTimer: Timer?
@@ -38,6 +52,8 @@ final class UsageStore: ObservableObject {
     private var usageTaskRunning = false
     private var limitsTaskRunning = false
     private var limitsBackoffUntil = Date.distantPast
+    private var directoryPairingTask: Task<Void, Never>?
+    private var directorySyncTask: Task<Void, Never>?
 
     /// Last two five-hour utilization readings, used for the slope-based
     /// "you'll hit the limit at HH:mm" prediction.
@@ -46,6 +62,8 @@ final class UsageStore: ObservableObject {
     init(limitsProvider: LimitsProvider = OAuthLimitsProvider()) {
         self.limitsProvider = limitsProvider
         self.settings = settingsManager.load()
+        self.directoryCredential = directoryCredentialStore.load()
+        self.directoryState = directoryCredential == nil ? .disconnected : .connected
     }
 
     // MARK: - Lifecycle
@@ -72,6 +90,8 @@ final class UsageStore: ObservableObject {
         fallbackTimer?.invalidate()
         limitsTimer?.invalidate()
         alternateTimer?.invalidate()
+        directoryPairingTask?.cancel()
+        directorySyncTask?.cancel()
     }
 
     private func rescheduleTimers() {
@@ -121,6 +141,7 @@ final class UsageStore: ObservableObject {
             self.usageTaskRunning = false
             self.isRefreshing = false
             self.didUpdate()
+            self.scheduleDirectorySync()
         }
     }
 
@@ -184,6 +205,114 @@ final class UsageStore: ObservableObject {
     }
 
     var settingsFilePath: String { settingsManager.settingsURL.path }
+
+    // MARK: - claudecode.directory
+
+    func connectDirectory() {
+        guard directoryState != .pairing else { return }
+        directoryPairingTask?.cancel()
+        directoryState = .pairing
+        directoryPairing = nil
+        directoryError = nil
+
+        directoryPairingTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let pairing = try await directoryClient.requestPairing(
+                    installationId: DirectoryIdentity.installationId,
+                    deviceName: DirectoryIdentity.deviceName,
+                    appVersion: DirectoryIdentity.appVersion
+                )
+                guard !Task.isCancelled else { return }
+                directoryPairing = pairing
+                NSWorkspace.shared.open(pairing.verificationUriComplete)
+
+                let deadline = Date().addingTimeInterval(TimeInterval(pairing.expiresIn))
+                while Date() < deadline, !Task.isCancelled {
+                    do {
+                        let credential = try await directoryClient.pollToken(deviceCode: pairing.deviceCode)
+                        guard directoryCredentialStore.save(credential) else {
+                            throw DirectoryClientError.server("Could not store the device credential in Keychain.")
+                        }
+                        directoryCredential = credential
+                        directoryState = .connected
+                        directoryPairing = nil
+                        directoryError = nil
+                        syncDirectoryNow()
+                        return
+                    } catch DirectoryClientError.authorizationPending {
+                        try? await Task.sleep(nanoseconds: UInt64(max(pairing.interval, 5)) * 1_000_000_000)
+                    }
+                }
+                if !Task.isCancelled { throw DirectoryClientError.expired }
+            } catch {
+                guard !Task.isCancelled else { return }
+                directoryState = .disconnected
+                directoryPairing = nil
+                directoryError = error.localizedDescription
+            }
+        }
+    }
+
+    func openDirectoryPairingPage() {
+        if let url = directoryPairing?.verificationUriComplete {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    func syncDirectoryNow() {
+        guard let credential = directoryCredential, !isDirectorySyncing else { return }
+        directorySyncTask?.cancel()
+        isDirectorySyncing = true
+        directoryError = nil
+        let buckets = snapshot?.syncBuckets ?? []
+        directorySyncTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await directoryClient.sync(
+                    buckets: buckets,
+                    credential: credential,
+                    appVersion: DirectoryIdentity.appVersion
+                )
+                guard !Task.isCancelled else { return }
+                directoryLastSyncAt = Date()
+            } catch DirectoryClientError.unauthorized {
+                directoryCredentialStore.delete()
+                directoryCredential = nil
+                directoryState = .disconnected
+                directoryError = DirectoryClientError.unauthorized.localizedDescription
+            } catch {
+                guard !Task.isCancelled else { return }
+                directoryError = error.localizedDescription
+            }
+            isDirectorySyncing = false
+        }
+    }
+
+    func disconnectDirectory() {
+        directoryPairingTask?.cancel()
+        directorySyncTask?.cancel()
+        let credential = directoryCredential
+        directoryCredentialStore.delete()
+        directoryCredential = nil
+        directoryPairing = nil
+        directoryState = .disconnected
+        isDirectorySyncing = false
+        directoryLastSyncAt = nil
+        directoryError = nil
+        guard let credential else { return }
+        Task { try? await directoryClient.disconnect(credential: credential) }
+    }
+
+    private func scheduleDirectorySync() {
+        guard directoryState == .connected, !isDirectorySyncing else { return }
+        directorySyncTask?.cancel()
+        directorySyncTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 15 * 1_000_000_000)
+            guard !Task.isCancelled else { return }
+            self?.syncDirectoryNow()
+        }
+    }
 
     // MARK: - Derived values
 

--- a/swift/Sources/CCSeva/Directory/DirectoryClient.swift
+++ b/swift/Sources/CCSeva/Directory/DirectoryClient.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+struct DirectoryPairing: Decodable {
+    let deviceCode: String
+    let userCode: String
+    let verificationUri: URL
+    let verificationUriComplete: URL
+    let expiresIn: Int
+    let interval: Int
+}
+
+private struct DirectoryTokenResponse: Decodable {
+    struct Account: Decodable {
+        let name: String?
+        let email: String
+    }
+
+    let accessToken: String
+    let deviceId: String
+    let account: Account
+}
+
+private struct DirectorySyncResponse: Decodable {
+    let accepted: Int
+    let syncedAt: String
+}
+
+enum DirectoryClientError: LocalizedError, Equatable {
+    case authorizationPending
+    case accessDenied
+    case expired
+    case unauthorized
+    case server(String)
+    case invalidResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .authorizationPending: return "Waiting for approval in your browser."
+        case .accessDenied: return "The connection request was denied."
+        case .expired: return "The pairing code expired. Start again."
+        case .unauthorized: return "This Mac was disconnected from claudecode.directory."
+        case .server(let message): return message
+        case .invalidResponse: return "claudecode.directory returned an invalid response."
+        }
+    }
+}
+
+struct DirectoryClient {
+    static let productionURL = URL(string: "https://claudecode.directory")!
+
+    let baseURL: URL
+    private let session: URLSession
+
+    init(baseURL: URL = DirectoryClient.configuredBaseURL, session: URLSession? = nil) {
+        self.baseURL = baseURL
+        if let session {
+            self.session = session
+        } else {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.timeoutIntervalForRequest = 20
+            configuration.timeoutIntervalForResource = 30
+            self.session = URLSession(configuration: configuration)
+        }
+    }
+
+    static var configuredBaseURL: URL {
+        guard let value = ProcessInfo.processInfo.environment["CCSEVA_DIRECTORY_URL"],
+              let url = URL(string: value), ["http", "https"].contains(url.scheme?.lowercased() ?? "")
+        else { return productionURL }
+        return url
+    }
+
+    func requestPairing(installationId: String, deviceName: String, appVersion: String) async throws -> DirectoryPairing {
+        let body: [String: String] = [
+            "installationId": installationId,
+            "deviceName": deviceName,
+            "appVersion": appVersion,
+        ]
+        let data = try await send(path: "/api/device/code", body: body)
+        guard let pairing = try? JSONDecoder().decode(DirectoryPairing.self, from: data) else {
+            throw DirectoryClientError.invalidResponse
+        }
+        return pairing
+    }
+
+    func pollToken(deviceCode: String) async throws -> DirectoryCredential {
+        let (data, response) = try await request(path: "/api/device/token", body: ["deviceCode": deviceCode])
+        switch response.statusCode {
+        case 200:
+            guard let result = try? JSONDecoder().decode(DirectoryTokenResponse.self, from: data) else {
+                throw DirectoryClientError.invalidResponse
+            }
+            return DirectoryCredential(
+                accessToken: result.accessToken,
+                deviceId: result.deviceId,
+                accountName: result.account.name,
+                accountEmail: result.account.email
+            )
+        case 403: throw DirectoryClientError.accessDenied
+        case 410: throw DirectoryClientError.expired
+        case 428: throw DirectoryClientError.authorizationPending
+        default: throw decodeServerError(data: data, status: response.statusCode)
+        }
+    }
+
+    func sync(buckets: [UsageSyncBucket], credential: DirectoryCredential, appVersion: String) async throws {
+        // Keep payloads bounded for old installations with years of history.
+        let chunks = buckets.isEmpty ? [[]] : stride(from: 0, to: buckets.count, by: 500).map {
+            Array(buckets[$0..<min($0 + 500, buckets.count)])
+        }
+        for chunk in chunks {
+            let payload = DirectorySyncPayload(appVersion: appVersion, buckets: chunk)
+            let data = try JSONEncoder.directory.encode(payload)
+            var request = URLRequest(url: endpoint("/api/sync/v1/usage"))
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("Bearer \(credential.accessToken)", forHTTPHeaderField: "Authorization")
+            request.httpBody = data
+            let (responseData, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else { throw DirectoryClientError.invalidResponse }
+            if http.statusCode == 401 { throw DirectoryClientError.unauthorized }
+            guard (200..<300).contains(http.statusCode),
+                  (try? JSONDecoder().decode(DirectorySyncResponse.self, from: responseData)) != nil
+            else { throw decodeServerError(data: responseData, status: http.statusCode) }
+        }
+    }
+
+    func disconnect(credential: DirectoryCredential) async throws {
+        var request = URLRequest(url: endpoint("/api/sync/v1/device"))
+        request.httpMethod = "DELETE"
+        request.setValue("Bearer \(credential.accessToken)", forHTTPHeaderField: "Authorization")
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw DirectoryClientError.invalidResponse }
+        if http.statusCode == 401 { throw DirectoryClientError.unauthorized }
+        guard (200..<300).contains(http.statusCode) else {
+            throw decodeServerError(data: data, status: http.statusCode)
+        }
+    }
+
+    private func send<T: Encodable>(path: String, body: T) async throws -> Data {
+        let (data, response) = try await request(path: path, body: body)
+        guard (200..<300).contains(response.statusCode) else {
+            throw decodeServerError(data: data, status: response.statusCode)
+        }
+        return data
+    }
+
+    private func request<T: Encodable>(path: String, body: T) async throws -> (Data, HTTPURLResponse) {
+        var request = URLRequest(url: endpoint(path))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(body)
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw DirectoryClientError.invalidResponse }
+        return (data, http)
+    }
+
+    private func endpoint(_ path: String) -> URL {
+        URL(string: path, relativeTo: baseURL)!.absoluteURL
+    }
+
+    private func decodeServerError(data: Data, status: Int) -> DirectoryClientError {
+        if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let error = object["error"] as? String {
+            return .server(error)
+        }
+        return .server("claudecode.directory returned HTTP \(status).")
+    }
+}
+
+private struct DirectorySyncPayload: Encodable {
+    let schemaVersion = 1
+    let generatedAt = Date()
+    let appVersion: String
+    let buckets: [Bucket]
+
+    init(appVersion: String, buckets: [UsageSyncBucket]) {
+        self.appVersion = appVersion
+        self.buckets = buckets.map(Bucket.init)
+    }
+
+    struct Bucket: Encodable {
+        let bucketStart: Date
+        let localDate: String
+        let timezone: String
+        let harness: String
+        let provider: String
+        let model: String
+        let inputTokens: Int
+        let outputTokens: Int
+        let cacheCreationTokens: Int
+        let cacheReadTokens: Int
+        let estimatedCostMicros: Int64
+        let eventCount: Int
+
+        init(_ bucket: UsageSyncBucket) {
+            bucketStart = bucket.bucketStart
+            localDate = bucket.localDate
+            timezone = bucket.timezone
+            harness = bucket.harness
+            provider = bucket.provider
+            model = bucket.model
+            inputTokens = bucket.tokens.input
+            outputTokens = bucket.tokens.output
+            cacheCreationTokens = bucket.tokens.cacheCreation
+            cacheReadTokens = bucket.tokens.cacheRead
+            estimatedCostMicros = bucket.estimatedCostMicros
+            eventCount = bucket.eventCount
+        }
+    }
+}
+
+private extension JSONEncoder {
+    static var directory: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}

--- a/swift/Sources/CCSeva/Directory/DirectoryCredentialStore.swift
+++ b/swift/Sources/CCSeva/Directory/DirectoryCredentialStore.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Security
+
+struct DirectoryCredential: Codable, Equatable {
+    let accessToken: String
+    let deviceId: String
+    let accountName: String?
+    let accountEmail: String
+}
+
+/// Stores only the claudecode.directory device credential. Claude's own OAuth
+/// credential is read by a separate component and is never copied into this item.
+final class DirectoryCredentialStore {
+    private let service = "com.iamshankhadeep.ccseva.directory"
+    private let account = "sync"
+
+    func load() -> DirectoryCredential? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data
+        else { return nil }
+        return try? JSONDecoder().decode(DirectoryCredential.self, from: data)
+    }
+
+    @discardableResult
+    func save(_ credential: DirectoryCredential) -> Bool {
+        guard let data = try? JSONEncoder().encode(credential) else { return false }
+        let base: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let update = [kSecValueData as String: data]
+        let status = SecItemUpdate(base as CFDictionary, update as CFDictionary)
+        if status == errSecSuccess { return true }
+        guard status == errSecItemNotFound else { return false }
+        var add = base
+        add[kSecValueData as String] = data
+        add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        return SecItemAdd(add as CFDictionary, nil) == errSecSuccess
+    }
+
+    func delete() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/swift/Sources/CCSeva/Directory/DirectoryIdentity.swift
+++ b/swift/Sources/CCSeva/Directory/DirectoryIdentity.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum DirectoryIdentity {
+    private static let installationKey = "ccseva.directory.installation-id"
+
+    static var installationId: String {
+        if let existing = UserDefaults.standard.string(forKey: installationKey), !existing.isEmpty {
+            return existing
+        }
+        let value = UUID().uuidString.lowercased()
+        UserDefaults.standard.set(value, forKey: installationKey)
+        return value
+    }
+
+    static var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "2.0.0-dev"
+    }
+
+    static var deviceName: String {
+        Host.current().localizedName ?? "Mac"
+    }
+}

--- a/swift/Sources/CCSeva/UI/SettingsView.swift
+++ b/swift/Sources/CCSeva/UI/SettingsView.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
                 menuBarSection
                 startupSection
                 refreshSection
+                directorySection
                 aboutSection
             }
             .padding(.bottom, 8)
@@ -126,6 +127,98 @@ struct SettingsView: View {
                 .foregroundStyle(Color.neutral500)
         }
         .warmCard()
+    }
+
+    private var directorySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                SectionHeader(title: "claudecode.directory")
+                Spacer()
+                Text(directoryStatusLabel)
+                    .font(.firaCode(9))
+                    .foregroundStyle(directoryStatusColor)
+            }
+
+            switch store.directoryState {
+            case .disconnected:
+                Text("Optionally sync aggregate token counts by day and model to your private dashboard.")
+                    .font(.firaCode(10))
+                    .foregroundStyle(Color.neutral400)
+                Button("Connect with GitHub") { store.connectDirectory() }
+                    .font(.firaCode(11))
+                    .buttonStyle(.borderedProminent)
+
+            case .pairing:
+                if let pairing = store.directoryPairing {
+                    Text("Verify this code in your browser")
+                        .font(.firaCode(10))
+                        .foregroundStyle(Color.neutral400)
+                    Text(pairing.userCode)
+                        .font(.firaCode(22, weight: .bold))
+                        .foregroundStyle(Color.claudePrimary)
+                        .textSelection(.enabled)
+                    Button("Open verification page") { store.openDirectoryPairingPage() }
+                        .font(.firaCode(11))
+                } else {
+                    HStack(spacing: 8) {
+                        ProgressView().controlSize(.small)
+                        Text("Creating a secure pairing code…").font(.firaCode(10))
+                    }
+                }
+
+            case .connected:
+                if let credential = store.directoryCredential {
+                    Text(credential.accountName ?? credential.accountEmail)
+                        .font(.firaCode(11, weight: .semibold))
+                        .foregroundStyle(Color.neutral100)
+                    Text(credential.accountEmail)
+                        .font(.firaCode(9))
+                        .foregroundStyle(Color.neutral400)
+                }
+                HStack(spacing: 10) {
+                    Button(store.isDirectorySyncing ? "Syncing…" : "Sync now") {
+                        store.syncDirectoryNow()
+                    }
+                    .font(.firaCode(11))
+                    .disabled(store.isDirectorySyncing)
+
+                    Button("Disconnect") { store.disconnectDirectory() }
+                        .font(.firaCode(11))
+                }
+                if let lastSync = store.directoryLastSyncAt {
+                    Text("Last synced \(lastSync.formatted(date: .abbreviated, time: .shortened))")
+                        .font(.firaCode(9))
+                        .foregroundStyle(Color.neutral400)
+                }
+            }
+
+            if let error = store.directoryError {
+                Text(error)
+                    .font(.firaCode(9))
+                    .foregroundStyle(Color.critFrom)
+            }
+
+            Text("Only daily/model token totals and estimated cost are uploaded. Prompts, responses, transcripts, project paths, and Claude credentials never leave this Mac.")
+                .font(.firaCode(9))
+                .foregroundStyle(Color.neutral500)
+        }
+        .warmCard()
+    }
+
+    private var directoryStatusLabel: String {
+        switch store.directoryState {
+        case .disconnected: return "NOT CONNECTED"
+        case .pairing: return "PAIRING"
+        case .connected: return store.isDirectorySyncing ? "SYNCING" : "CONNECTED"
+        }
+    }
+
+    private var directoryStatusColor: Color {
+        switch store.directoryState {
+        case .disconnected: return .neutral500
+        case .pairing: return .warnFrom
+        case .connected: return .safeFrom
+        }
     }
 
     // MARK: - Bindings

--- a/swift/Tests/CCSevaTests/DirectoryClientTests.swift
+++ b/swift/Tests/CCSevaTests/DirectoryClientTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import XCTest
+@testable import CCSeva
+
+final class DirectoryClientTests: XCTestCase {
+    override func tearDown() {
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testPairingRequestAndResponse() async throws {
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/device/code")
+            XCTAssertEqual(request.httpMethod, "POST")
+            let body = try Self.requestBody(request)
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
+            XCTAssertEqual(json["installationId"], "install-123")
+            return Self.response(
+                request,
+                status: 200,
+                json: #"{"deviceCode":"secret","userCode":"ABCD-EFGH","verificationUri":"https://claudecode.directory/device","verificationUriComplete":"https://claudecode.directory/device?user_code=ABCD-EFGH","expiresIn":600,"interval":5}"#
+            )
+        }
+
+        let pairing = try await client().requestPairing(
+            installationId: "install-123",
+            deviceName: "Test Mac",
+            appVersion: "2.0.0"
+        )
+        XCTAssertEqual(pairing.userCode, "ABCD-EFGH")
+        XCTAssertEqual(pairing.interval, 5)
+    }
+
+    func testPendingAuthorizationIsTyped() async throws {
+        MockURLProtocol.requestHandler = { request in
+            Self.response(request, status: 428, json: #"{"error":"authorization_pending"}"#)
+        }
+
+        do {
+            _ = try await client().pollToken(deviceCode: String(repeating: "x", count: 40))
+            XCTFail("Expected authorizationPending")
+        } catch let error as DirectoryClientError {
+            XCTAssertEqual(error, .authorizationPending)
+        }
+    }
+
+    func testSyncUsesBearerAndContainsOnlyAggregateFields() async throws {
+        var bucket = UsageSyncBucket(
+            bucketStart: Date(timeIntervalSince1970: 1_775_000_000),
+            localDate: "2026-04-01",
+            timezone: "Asia/Kolkata",
+            harness: "claude-code",
+            provider: "anthropic",
+            model: "claude-sonnet-4"
+        )
+        bucket.tokens = TokenCounts(input: 10, output: 2, cacheCreation: 3, cacheRead: 40)
+        bucket.estimatedCostMicros = 1234
+        bucket.eventCount = 2
+
+        MockURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.url?.path, "/api/sync/v1/usage")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer ccseva_test")
+            let body = try Self.requestBody(request)
+            let text = try XCTUnwrap(String(data: body, encoding: .utf8))
+            XCTAssertTrue(text.contains("claude-sonnet-4"))
+            XCTAssertTrue(text.contains("cacheReadTokens"))
+            XCTAssertFalse(text.contains("project"))
+            XCTAssertFalse(text.contains("prompt"))
+            XCTAssertFalse(text.contains("content"))
+            return Self.response(request, status: 200, json: #"{"accepted":1,"syncedAt":"2026-08-03T12:00:00Z"}"#)
+        }
+
+        let credential = DirectoryCredential(
+            accessToken: "ccseva_test",
+            deviceId: "device-1",
+            accountName: "Test",
+            accountEmail: "test@example.com"
+        )
+        try await client().sync(buckets: [bucket], credential: credential, appVersion: "2.0.0")
+    }
+
+    private func client() -> DirectoryClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return DirectoryClient(
+            baseURL: URL(string: "https://claudecode.directory")!,
+            session: URLSession(configuration: configuration)
+        )
+    }
+
+    private static func response(
+        _ request: URLRequest,
+        status: Int,
+        json: String
+    ) -> (HTTPURLResponse, Data) {
+        (
+            HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!,
+            Data(json.utf8)
+        )
+    }
+
+    private static func requestBody(_ request: URLRequest) throws -> Data {
+        if let body = request.httpBody { return body }
+        let stream = try XCTUnwrap(request.httpBodyStream)
+        stream.open()
+        defer { stream.close() }
+        var result = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count < 0 { throw try XCTUnwrap(stream.streamError) }
+            if count == 0 { break }
+            result.append(buffer, count: count)
+        }
+        return result
+    }
+}
+
+private final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: DirectoryClientError.invalidResponse)
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/swift/Tests/CCSevaTests/DirectorySyncTests.swift
+++ b/swift/Tests/CCSevaTests/DirectorySyncTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import CCSeva
+
+final class DirectorySyncTests: XCTestCase {
+    func testSyncBucketsAggregateByLocalDayAndModel() throws {
+        let timestamp = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-03T10:00:00Z"))
+        let entries = [
+            entry(at: timestamp, model: "claude-sonnet-4", input: 10, output: 5, cacheRead: 20, project: "secret-client"),
+            entry(at: timestamp.addingTimeInterval(60), model: "claude-sonnet-4", input: 3, output: 2, cacheRead: 7, project: "other-secret"),
+            entry(at: timestamp, model: "claude-opus-4", input: 4, output: 1, cacheRead: 0, project: "secret-client"),
+        ]
+
+        let snapshot = Aggregator.buildSnapshot(entries: entries, stats: ScanStats(), now: timestamp)
+
+        XCTAssertEqual(snapshot.syncBuckets.count, 2)
+        let sonnet = try XCTUnwrap(snapshot.syncBuckets.first { $0.model == "claude-sonnet-4" })
+        XCTAssertEqual(sonnet.harness, "claude-code")
+        XCTAssertEqual(sonnet.provider, "anthropic")
+        XCTAssertEqual(sonnet.tokens.input, 13)
+        XCTAssertEqual(sonnet.tokens.output, 7)
+        XCTAssertEqual(sonnet.tokens.cacheRead, 27)
+        XCTAssertEqual(sonnet.eventCount, 2)
+    }
+
+    func testSyncBucketsDoNotExposeProjectNames() throws {
+        let timestamp = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-08-03T10:00:00Z"))
+        let snapshot = Aggregator.buildSnapshot(
+            entries: [entry(at: timestamp, model: "claude-sonnet-4", input: 1, output: 1, cacheRead: 0, project: "private-repository")],
+            stats: ScanStats(),
+            now: timestamp
+        )
+
+        let mirrorLabels = Mirror(reflecting: try XCTUnwrap(snapshot.syncBuckets.first)).children.compactMap(\.label)
+        XCTAssertFalse(mirrorLabels.contains("projectName"))
+        XCTAssertFalse(mirrorLabels.contains("requestId"))
+        XCTAssertFalse(mirrorLabels.contains("content"))
+    }
+
+    private func entry(
+        at timestamp: Date,
+        model: String,
+        input: Int,
+        output: Int,
+        cacheRead: Int,
+        project: String
+    ) -> UsageEntry {
+        UsageEntry(
+            timestamp: timestamp,
+            model: model,
+            inputTokens: input,
+            outputTokens: output,
+            cacheCreationTokens: 0,
+            cacheReadTokens: cacheRead,
+            costUSD: 0.01,
+            projectName: project,
+            priced: true
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add browser-based claudecode.directory device pairing from the menu-bar settings
- keep the revocable directory credential in a dedicated, device-only Keychain item
- aggregate Claude Code usage locally by day and model before upload
- sync only token counts, estimated cost, harness/provider/model labels, timezone, and event count
- add manual sync, automatic debounced sync, disconnect, and account status UI
- explicitly exclude prompts, responses, transcripts, project paths, and Claude credentials
- add Swift protocol and privacy-boundary tests

## Verification

- `swift test` (5 tests)
- `swift build`
- `git diff --check`
- end-to-end protocol verified against the website implementation, including idempotency and revocation