### PR TITLE
fix: avoid flaky DMG mounts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,12 @@ jobs:
       run: npm test
       continue-on-error: true  # Tests might not exist yet
     
-    - name: Package application (macOS only)
+    # Building a DMG mounts /Volumes/CCSeva and is flaky on shared GitHub
+    # runners. CI only needs to prove Electron can assemble the application;
+    # release workflows remain responsible for producing distributable DMGs.
+    - name: Package application directory (macOS only)
       if: matrix.node-version == '20.x'
-      run: npm run pack
+      run: npm run pack -- --dir
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

The Electron CI job only needs to prove that the application can be packaged. Building a distributable DMG mounts `/Volumes/CCSeva`, which intermittently fails to detach on shared GitHub macOS runners.

Use electron-builder directory packaging in CI instead. Release workflows and local release commands still produce DMGs unchanged.

## Verification

- `npm run pack -- --dir`
- `git diff --check`