### PR TITLE
fix: resolve resources from signed app bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
       run: |
         test -d dist/CCSeva.app
         test -d dist/CCSeva.app/Contents/Resources/CCSeva_CCSeva.bundle
+        dist/CCSeva.app/Contents/MacOS/CCSeva --verify-resources
 
     - name: Smoke test (--diagnose)
       working-directory: swift

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "date-fns-tz": "^3.2.0",
         "lucide-react": "^0.523.0",
         "next-themes": "^0.4.6",
-        "postcss": "8.5.18",
+        "postcss": "8.5.25",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "sonner": "^2.0.7",
@@ -6748,9 +6748,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -7309,9 +7309,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7328,7 +7328,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.523.0",
     "next-themes": "^0.4.6",
-    "postcss": "8.5.18",
+    "postcss": "8.5.25",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "sonner": "^2.0.7",

--- a/swift/Sources/CCSeva/App/AppDelegate.swift
+++ b/swift/Sources/CCSeva/App/AppDelegate.swift
@@ -14,6 +14,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Diagnose.run()
             exit(0)
         }
+        if CommandLine.arguments.contains("--verify-resources") {
+            let requiredResources = [
+                ("FiraCode-Regular", "ttf"),
+                ("AppIcon", "png"),
+            ]
+            for (name, extensionName) in requiredResources {
+                guard CCSevaResources.bundle.url(forResource: name, withExtension: extensionName) != nil else {
+                    FileHandle.standardError.write(
+                        Data("Missing bundled resource: \(name).\(extensionName)\n".utf8)
+                    )
+                    exit(1)
+                }
+            }
+            print("CCSeva packaged resources verified")
+            exit(0)
+        }
         let app = NSApplication.shared
         let delegate = AppDelegate()
         retainedDelegate = delegate

--- a/swift/Sources/CCSeva/Support/CCSevaResources.swift
+++ b/swift/Sources/CCSeva/Support/CCSevaResources.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Resolves SwiftPM resources in both execution modes:
+/// - packaged app: Contents/Resources/CCSeva_CCSeva.bundle
+/// - direct SwiftPM executable/tests: generated Bundle.module location
+enum CCSevaResources {
+    static let bundle: Bundle = {
+        if let resourceURL = Bundle.main.resourceURL,
+           let packagedBundle = Bundle(
+               url: resourceURL.appendingPathComponent("CCSeva_CCSeva.bundle", isDirectory: true)
+           )
+        {
+            return packagedBundle
+        }
+        return Bundle.module
+    }()
+}

--- a/swift/Sources/CCSeva/UI/Theme.swift
+++ b/swift/Sources/CCSeva/UI/Theme.swift
@@ -140,7 +140,7 @@ enum FiraCode {
         ]
         var count = 0
         for face in faces {
-            guard let url = Bundle.module.url(forResource: face, withExtension: "ttf") else {
+            guard let url = CCSevaResources.bundle.url(forResource: face, withExtension: "ttf") else {
                 continue
             }
             var error: Unmanaged<CFError>?
@@ -248,12 +248,12 @@ struct GradientIconTile: View {
 // MARK: - App icon
 
 /// The real CCSeva app icon (assets/icon.icns), bundled as a resource and shown
-/// in the header. Loaded once from Bundle.module.
+/// in the header. Loaded once from the packaged SwiftPM resource bundle.
 struct AppIconImage: View {
     var size: CGFloat = 28
 
     private static let nsImage: NSImage? = {
-        guard let url = Bundle.module.url(forResource: "AppIcon", withExtension: "png") else {
+        guard let url = CCSevaResources.bundle.url(forResource: "AppIcon", withExtension: "png") else {
             return nil
         }
         return NSImage(contentsOf: url)

--- a/swift/scripts/build-app.sh
+++ b/swift/scripts/build-app.sh
@@ -28,9 +28,9 @@ elif [ -f ../assets/icon.icns ]; then
 	cp ../assets/icon.icns "$APP/Contents/Resources/AppIcon.icns"
 fi
 
-# SwiftPM emits bundled resources (Fira Code fonts) into CCSeva_CCSeva.bundle next
-# to the binary. Bundle.module resolves it relative to the executable at runtime,
-# so it must sit in Contents/Resources alongside the app's other resources.
+# Keep the SwiftPM resource bundle in the standard signed-app resource directory.
+# CCSevaResources resolves this location in packaged builds and falls back to
+# Bundle.module when running directly through SwiftPM.
 RESOURCE_BUNDLE="$BIN_DIR/CCSeva_CCSeva.bundle"
 if [ -d "$RESOURCE_BUNDLE" ]; then
 	cp -R "$RESOURCE_BUNDLE" "$APP/Contents/Resources/"


### PR DESCRIPTION
## Summary

- keep the SwiftPM resource bundle in the standard signed-app `Contents/Resources` directory
- resolve packaged resources explicitly while retaining `Bundle.module` for direct SwiftPM execution
- add a packaged-app resource verification mode and run it in CI

This fixes the notarized v2.0.1 app exiting at launch because SwiftPM looked for its resource bundle outside the signed `Contents` hierarchy.

## Verification

- `swift test` (5 tests)
- assembled v2.0.2 app locally
- packaged resource verification passed
- strict deep code-signature verification passed
- launched the packaged app and confirmed it remained running
- `git diff --check`